### PR TITLE
Implement support for Platform Automation

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -106,7 +106,7 @@ func init() {
 	bindFlagAndEnvVar(collectCmd, EnvTypeFlag, "", fmt.Sprintf("``Specify environment type (sandbox, development, qa, pre-production, production) [$%s]", EnvTypeKey), EnvTypeKey)
 	bindFlagAndEnvVar(collectCmd, OpsManagerTimeoutFlag, 30, fmt.Sprintf("``Ops Manager http request timeout in seconds [$%s]", OpsManagerTimeoutKey), OpsManagerTimeoutKey)
 	bindFlagAndEnvVar(collectCmd, SkipTlsVerifyFlag, false, fmt.Sprintf("``Skip TLS validation on http requests to Ops Manager [$%s]\n", SkipTlsVerifyKey), SkipTlsVerifyKey)
-	bindFlagAndEnvVar(collectCmd, SkipTlsVerifyAliasFlag, "", fmt.Sprintf("``Ops Manager URL [$%s]", SkipTlsVerifyKeyAlias), SkipTlsVerifyKeyAlias)
+	bindFlagAndEnvVar(collectCmd, SkipTlsVerifyAliasFlag, false, fmt.Sprintf("``Ops Manager URL [$%s]", SkipTlsVerifyKeyAlias), SkipTlsVerifyKeyAlias)
 	collectCmd.Flags().MarkHidden(SkipTlsVerifyAliasFlag)
 
 	bindFlagAndEnvVar(collectCmd, CfApiURLFlag, "", fmt.Sprintf("``CF API URL for UAA authentication to access Usage Service [$%s]", CfApiURLKey), CfApiURLKey)
@@ -209,14 +209,17 @@ func handleAliases(c *cobra.Command) {
 		viper.RegisterAlias(OpsManagerURLFlag, OpsManagerURLAliasFlag)
 	}
 
-	var passedAsFlag bool
+	var originalPassedAsFlag, aliasedPassedAsFlag bool
 	c.Flags().Visit(func(flag *pflag.Flag) {
-		if flag.Name == SkipTlsVerifyFlag {
-			passedAsFlag = true
+		switch flag.Name {
+		case SkipTlsVerifyFlag:
+			originalPassedAsFlag = true
+		case SkipTlsVerifyAliasFlag:
+			aliasedPassedAsFlag = true
 		}
 	})
 
-	if !passedAsFlag && os.Getenv(SkipTlsVerifyKey) == "" {
+	if (!originalPassedAsFlag && os.Getenv(SkipTlsVerifyKey) == "") || aliasedPassedAsFlag {
 		viper.RegisterAlias(SkipTlsVerifyFlag, SkipTlsVerifyAliasFlag)
 	}
 }

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -158,20 +158,7 @@ func collect(c *cobra.Command, _ []string) error {
 		}
 	}
 
-	if viper.GetString(OpsManagerURLFlag) == "" {
-		viper.RegisterAlias(OpsManagerURLFlag, OpsManagerURLAliasFlag)
-	}
-
-	found := false
-	c.Flags().Visit(func(flag *pflag.Flag) {
-		if flag.Name == SkipTlsVerifyFlag {
-			found = true
-		}
-	})
-
-	if !found && os.Getenv(SkipTlsVerifyKey) == "" {
-		viper.RegisterAlias(SkipTlsVerifyFlag, SkipTlsVerifyAliasFlag)
-	}
+	handleAliases(c)
 
 	if err := verifyRequiredConfig(OpsManagerURLFlag, EnvTypeFlag, OutputPathFlag); err != nil {
 		return err
@@ -215,6 +202,23 @@ func collect(c *cobra.Command, _ []string) error {
 	logger.Printf("Wrote output to %s\n", tarFilePath)
 	logger.Println("Success!")
 	return nil
+}
+
+func handleAliases(c *cobra.Command) {
+	if viper.GetString(OpsManagerURLFlag) == "" {
+		viper.RegisterAlias(OpsManagerURLFlag, OpsManagerURLAliasFlag)
+	}
+
+	var passedAsFlag bool
+	c.Flags().Visit(func(flag *pflag.Flag) {
+		if flag.Name == SkipTlsVerifyFlag {
+			passedAsFlag = true
+		}
+	})
+
+	if !passedAsFlag && os.Getenv(SkipTlsVerifyKey) == "" {
+		viper.RegisterAlias(SkipTlsVerifyFlag, SkipTlsVerifyAliasFlag)
+	}
 }
 
 func useConfigFile() bool {

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/spf13/pflag"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -31,7 +32,9 @@ import (
 )
 
 const (
+	ConfigFileKey                = "CONFIG_FILE"
 	OpsManagerURLKey             = "OPS_MANAGER_URL"
+	OpsManagerURLAliasKey        = "TARGET"
 	OpsManagerUsernameKey        = "OPS_MANAGER_USERNAME"
 	OpsManagerPasswordKey        = "OPS_MANAGER_PASSWORD"
 	OpsManagerClientIdKey        = "OPS_MANAGER_CLIENT_ID"
@@ -40,6 +43,7 @@ const (
 	EnvTypeKey                   = "ENV_TYPE"
 	OutputPathKey                = "OUTPUT_DIR"
 	SkipTlsVerifyKey             = "INSECURE_SKIP_TLS_VERIFY"
+	SkipTlsVerifyKeyAlias        = "SKIP_SSL_VALIDATION"
 	WithCredhubInfoKey           = "WITH_CREDHUB_INFO"
 	UsageServiceURLKey           = "USAGE_SERVICE_URL"
 	UsageServiceClientIDKey      = "USAGE_SERVICE_CLIENT_ID"
@@ -47,7 +51,9 @@ const (
 	CfApiURLKey                  = "CF_API_URL"
 	UsageServiceSkipTlsVerifyKey = "USAGE_SERVICE_INSECURE_SKIP_TLS_VERIFY"
 
+	ConfigFlag                    = "config"
 	OpsManagerURLFlag             = "url"
+	OpsManagerURLAliasFlag        = "target"
 	OpsManagerUsernameFlag        = "username"
 	OpsManagerPasswordFlag        = "password"
 	OpsManagerClientIdFlag        = "client-id"
@@ -57,6 +63,7 @@ const (
 	EnvTypeFlag                   = "env-type"
 	OutputPathFlag                = "output-dir"
 	SkipTlsVerifyFlag             = "insecure-skip-tls-verify"
+	SkipTlsVerifyAliasFlag        = "skip-ssl-validation"
 	UsageServiceURLFlag           = "usage-service-url"
 	UsageServiceClientIDFlag      = "usage-service-client-id"
 	UsageServiceClientSecretFlag  = "usage-service-client-secret"
@@ -87,7 +94,11 @@ var collectCmd = &cobra.Command{
 }
 
 func init() {
+	bindFlagAndEnvVar(collectCmd, ConfigFlag, "", fmt.Sprintf("``Config file for all other command line arguments [$%s]", ConfigFileKey), ConfigFileKey)
 	bindFlagAndEnvVar(collectCmd, OpsManagerURLFlag, "", fmt.Sprintf("``Ops Manager URL [$%s]", OpsManagerURLKey), OpsManagerURLKey)
+	bindFlagAndEnvVar(collectCmd, OpsManagerURLAliasFlag, "", fmt.Sprintf("``Ops Manager URL [$%s]", OpsManagerURLAliasKey), OpsManagerURLAliasKey)
+	collectCmd.Flags().MarkHidden(OpsManagerURLAliasFlag)
+
 	bindFlagAndEnvVar(collectCmd, OpsManagerUsernameFlag, "", fmt.Sprintf("``Ops Manager username [$%s]", OpsManagerUsernameKey), OpsManagerUsernameKey)
 	bindFlagAndEnvVar(collectCmd, OpsManagerPasswordFlag, "", fmt.Sprintf("``Ops Manager password [$%s]", OpsManagerPasswordKey), OpsManagerPasswordKey)
 	bindFlagAndEnvVar(collectCmd, OpsManagerClientIdFlag, "", fmt.Sprintf("``Ops Manager client id [$%s]", OpsManagerClientIdKey), OpsManagerClientIdKey)
@@ -95,6 +106,8 @@ func init() {
 	bindFlagAndEnvVar(collectCmd, EnvTypeFlag, "", fmt.Sprintf("``Specify environment type (sandbox, development, qa, pre-production, production) [$%s]", EnvTypeKey), EnvTypeKey)
 	bindFlagAndEnvVar(collectCmd, OpsManagerTimeoutFlag, 30, fmt.Sprintf("``Ops Manager http request timeout in seconds [$%s]", OpsManagerTimeoutKey), OpsManagerTimeoutKey)
 	bindFlagAndEnvVar(collectCmd, SkipTlsVerifyFlag, false, fmt.Sprintf("``Skip TLS validation on http requests to Ops Manager [$%s]\n", SkipTlsVerifyKey), SkipTlsVerifyKey)
+	bindFlagAndEnvVar(collectCmd, SkipTlsVerifyAliasFlag, "", fmt.Sprintf("``Ops Manager URL [$%s]", SkipTlsVerifyKeyAlias), SkipTlsVerifyKeyAlias)
+	collectCmd.Flags().MarkHidden(SkipTlsVerifyAliasFlag)
 
 	bindFlagAndEnvVar(collectCmd, CfApiURLFlag, "", fmt.Sprintf("``CF API URL for UAA authentication to access Usage Service [$%s]", CfApiURLKey), CfApiURLKey)
 	bindFlagAndEnvVar(collectCmd, UsageServiceURLFlag, "", fmt.Sprintf("``Usage Service URL [$%s]", UsageServiceURLKey), UsageServiceURLKey)
@@ -137,6 +150,29 @@ Usage Service and/or Credhub) and outputs the content to the configured director
 }
 
 func collect(c *cobra.Command, _ []string) error {
+	if useConfigFile() {
+		viper.SetConfigFile(viper.GetString(ConfigFlag))
+		err := viper.ReadInConfig()
+		if err != nil {
+			return fmt.Errorf("error reading config file: %s \n", err)
+		}
+	}
+
+	if viper.GetString(OpsManagerURLFlag) == "" {
+		viper.RegisterAlias(OpsManagerURLFlag, OpsManagerURLAliasFlag)
+	}
+
+	found := false
+	c.Flags().Visit(func(flag *pflag.Flag) {
+		if flag.Name == SkipTlsVerifyFlag {
+			found = true
+		}
+	})
+
+	if !found && os.Getenv(SkipTlsVerifyKey) == "" {
+		viper.RegisterAlias(SkipTlsVerifyFlag, SkipTlsVerifyAliasFlag)
+	}
+
 	if err := verifyRequiredConfig(OpsManagerURLFlag, EnvTypeFlag, OutputPathFlag); err != nil {
 		return err
 	}
@@ -179,6 +215,10 @@ func collect(c *cobra.Command, _ []string) error {
 	logger.Printf("Wrote output to %s\n", tarFilePath)
 	logger.Println("Success!")
 	return nil
+}
+
+func useConfigFile() bool {
+	return viper.GetString(ConfigFlag) != ""
 }
 
 func anyUsageServiceConfigsProvided() bool {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,6 @@ func verifyRequiredConfig(keys ...string) error {
 	for _, k := range keys {
 		if viper.GetString(k) == "" {
 			missingFlags = append(missingFlags, "--"+k)
-
 		}
 	}
 

--- a/integration/collect_test.go
+++ b/integration/collect_test.go
@@ -82,14 +82,14 @@ var _ = Describe("Collect", func() {
 		})
 
 		It("accepts an aliased url in the config file configuration", func() {
-			config := fmt.Sprintf(`
-target: %s
-username: some-username
-password: some-password
-env-type: "Development"
-insecure-skip-tls-verify: true
-output-dir: %s
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"target": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": true,
+				"output-dir": "%s"
+			}`,	opsManagerServer.URL(), outputDirPath)
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -105,14 +105,14 @@ output-dir: %s
 		})
 
 		It("does not accept an aliased url in config file configuration if url is defined as a flag", func() {
-			config := fmt.Sprintf(`
-target: invalid.url.example.com
-username: some-username
-password: some-password
-env-type: "Development"
-insecure-skip-tls-verify: true
-output-dir: %s
-`, outputDirPath)
+			config := fmt.Sprintf(fmt.Sprintf(`{
+				"target": "invalid.url.example.com",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": true,
+				"output-dir": "%s"
+			}`, outputDirPath))
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -131,14 +131,14 @@ output-dir: %s
 		})
 
 		It("does not accept an aliased url in config file configuration if url is defined as a flag", func() {
-			config := fmt.Sprintf(`
-target: invalid.url.example.com
-username: some-username
-password: some-password
-env-type: "Development"
-insecure-skip-tls-verify: true
-output-dir: %s
-`, outputDirPath)
+			config := fmt.Sprintf(`{
+				"target": "invalid.url.example.com",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": true,
+				"output-dir": "%s"
+			}`, outputDirPath)
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -157,14 +157,14 @@ output-dir: %s
 		})
 
 		It("accepts an aliased skip tls validation in the config file configuration", func() {
-			config := fmt.Sprintf(`
-url: %s
-username: some-username
-password: some-password
-env-type: "Development"
-skip-ssl-validation: true
-output-dir: %s
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"url": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"skip-ssl-validation": true,
+				"output-dir": "%s"
+			}`, opsManagerServer.URL(), outputDirPath)
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -180,14 +180,15 @@ output-dir: %s
 		})
 
 		It("does not accept an aliased skip tls validation in config file configuration if skip tls validation is defined as a flag", func() {
-			config := fmt.Sprintf(`
-url: %s
-username: some-username
-password: some-password
-env-type: "Development"
-skip-ssl-validation: false
-output-dir: %s
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(
+				`{
+				"url": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"skip-ssl-validation": false,
+				"output-dir": "%s"
+			}`, opsManagerServer.URL(), outputDirPath)
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -206,14 +207,14 @@ output-dir: %s
 		})
 
 		It("does not accept an aliased skip tls validation in config file configuration if skip tls validation is defined as an environment variable", func() {
-			config := fmt.Sprintf(`
-url: %s
-username: some-username
-password: some-password
-env-type: "Development"
-skip-ssl-validation: false
-output-dir: %s
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"url": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"skip-ssl-validation": "false",
+				"output-dir": "%s"
+			}`, opsManagerServer.URL(), outputDirPath)
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -251,14 +252,15 @@ output-dir: %s
 	DescribeTable(
 		"succeeds with valid env type configuration from a config file",
 		func(envType string) {
-			config := fmt.Sprintf(`
-env-type: %s
-url: %s
-username: some-username
-password: some-password
-insecure-skip-tls-verify: true
-output-dir: %s
-`, envType, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"env-type": "%s",
+				"url": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": "true",
+				"output-dir": "%s"
+			}`, envType, opsManagerServer.URL(), outputDirPath)
 
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
@@ -336,14 +338,14 @@ output-dir: %s
 		})
 
 		It("succeeds with config file configuration", func() {
-			config := fmt.Sprintf(`
-url: %s
-username: some-username
-password: some-password
-env-type: "Development"
-insecure-skip-tls-verify: true
-output-dir: %s
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"url": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": "true",
+				"output-dir": "%s"
+			}`, opsManagerServer.URL(), outputDirPath)
 
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
@@ -398,14 +400,14 @@ output-dir: %s
 		})
 
 		It("succeeds with config file configuration", func() {
-			config := fmt.Sprintf(`
-url: %s
-client-id: some-client-id
-client-secret: some-client-secret
-env-type: "Development"
-insecure-skip-tls-verify: true
-output-dir: %s
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"url": "%s",
+				"client-id": "some-client-id",
+				"client-secret": "some-client-secret",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": "true",
+				"output-dir": "%s"
+			}`, opsManagerServer.URL(), outputDirPath)
 
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
@@ -480,14 +482,15 @@ output-dir: %s
 		})
 
 		It("uses the timeout specified by config file configuration", func() {
-			config := fmt.Sprintf(`
-ops-manager-timeout: 1
-url: %s
-client-id: whatever
-client-secret: whatever
-env-type: "Development"
-output-dir: %s
-`, slowServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"ops-manager-timeout": 1,
+				"url": "%s",
+				"client-id": "whatever",
+				"client-secret": "whatever",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": "true",
+				"output-dir": "%s"
+			}`, slowServer.URL(), outputDirPath)
 
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
@@ -567,20 +570,20 @@ output-dir: %s
 		})
 
 		It("uses the usage service client credentials specified by config file configuration", func() {
-			config := fmt.Sprintf(`
-ops-manager-timeout: 1
-url: %s
-client-id: whatever
-client-secret: whatever
-insecure-skip-tls-verify: true
-env-type: "Development"
-output-dir: %s
-cf-api-url: %s
-usage-service-url: %s
-usage-service-client-id: best-usage-service-client-id
-usage-service-client-secret: best-usage-service-client-secret
-usage-service-insecure-skip-tls-verify: true
-`, opsManagerServer.URL(), outputDirPath, cfService.URL(), usageService.URL())
+			config := fmt.Sprintf(`{
+				"ops-manager-timeout": 1,
+				"url": "%s",
+				"client-id": "whatever",
+				"client-secret": "whatever",
+				"insecure-skip-tls-verify": true,
+				"env-type": "Development",
+				"output-dir": "%s",
+				"cf-api-url": "%s",
+				"usage-service-url": "%s",
+				"usage-service-client-id": "best-usage-service-client-id",
+				"usage-service-client-secret": "best-usage-service-client-secret",
+				"usage-service-insecure-skip-tls-verify": true
+			}`, opsManagerServer.URL(), outputDirPath, cfService.URL(), usageService.URL())
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())
@@ -765,15 +768,15 @@ usage-service-insecure-skip-tls-verify: true
 		})
 
 		It("collects information from credhub as well as ops manager with config file configuration", func() {
-			config := fmt.Sprintf(`
-url: %s
-username: some-username
-password: some-password
-env-type: "Development"
-insecure-skip-tls-verify: true
-output-dir: %s
-with-credhub-info: true
-`, opsManagerServer.URL(), outputDirPath)
+			config := fmt.Sprintf(`{
+				"url": "%s",
+				"username": "some-username",
+				"password": "some-password",
+				"env-type": "Development",
+				"insecure-skip-tls-verify": "true",
+				"output-dir": "%s",
+				"with-credhub-info": "true"
+			}`, opsManagerServer.URL(), outputDirPath)
 			configFile := filepath.Join(configDirPath, "config.yml")
 			err := ioutil.WriteFile(configFile, []byte(config), 0755)
 			Expect(err).ToNot(HaveOccurred())

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"fmt"
 )
 
 func TestAqueductCollector(t *testing.T) {

--- a/integration/send_test.go
+++ b/integration/send_test.go
@@ -98,8 +98,8 @@ var _ = Describe("Send", func() {
 
 			dataLoader.RouteToHandler(http.MethodPost, operations.PostPath, ghttp.CombineHandlers(
 				ghttp.VerifyHeader(http.Header{
-					"Authorization":                           []string{fmt.Sprintf("Bearer %s", validApiKey)},
-					"Content-Type":                            []string{operations.TarMimeType},
+					"Authorization": []string{fmt.Sprintf("Bearer %s", validApiKey)},
+					"Content-Type":  []string{operations.TarMimeType},
 					operations.HTTPSenderVersionRequestHeader: []string{testVersion},
 				}),
 				ghttp.VerifyBody(srcContentBytes),
@@ -161,8 +161,8 @@ var _ = Describe("Send", func() {
 
 				dataLoader.RouteToHandler(http.MethodPost, operations.PostPath, ghttp.CombineHandlers(
 					ghttp.VerifyHeader(http.Header{
-						"Authorization":                           []string{fmt.Sprintf("Bearer %s", validApiKey)},
-						"Content-Type":                            []string{operations.TarMimeType},
+						"Authorization": []string{fmt.Sprintf("Bearer %s", validApiKey)},
+						"Content-Type":  []string{operations.TarMimeType},
 						operations.HTTPSenderVersionRequestHeader: []string{testVersion},
 					}),
 					ghttp.VerifyBody(srcContentBytes),


### PR DESCRIPTION
Includes the following:
- Addition of config files to match patterns with `om` commands used in platform automation and create a consistent experience for users
- alias the `url` flag to `target`, and `insecure-skip-tls-verify` to `skip-ssl-validation` to create parity with `om`. This way, users do not have to have nearly identical files with only two different named values when using this tool with platform automation

Behavior maintained:
- flags will take absolute precedence, as defined by viper
- env vars will take precedence over files, as defined by viper
- `url` and `insecure-skip-tls-verify` remain and are unchanged
- `skip-ssl-validation` and `target` do not show up in the help for telemetry, but could be used if someone knew it was there. The idea being that these are "secret flags" that are available for support in the platform automation product, and minimally intrusive to the telemetry binary